### PR TITLE
Fix class -> className error

### DIFF
--- a/src/components/FeaturedItem.jsx
+++ b/src/components/FeaturedItem.jsx
@@ -3,11 +3,11 @@ import React from "react";
 // Placeholders for now, will add functionality to call details (image, menu item, description, price)
 const FeaturedItem = () => {
     return(
-        <section class="featured-item">
-            <div class="item-image">
+        <section className="featured-item">
+            <div className="item-image">
                <img src="../assets/shredded-shroom.png" alt="Shredded Shroom Sandwich"></img>
             </div>
-            <div class="item-description">
+            <div className="item-description">
                 <h2>Item of the Month!</h2>
                 <h3>Filler menu item title.</h3>
                 <p>This is filler text for where the item description will go.</p>


### PR DESCRIPTION
In FeaturedItem component, className was class. Kept throwing error in console. Quick fix.