### PR TITLE
add node modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+node_modules


### PR DESCRIPTION
I'm not sure what I did here... I have a habit of switching to `main` instead of `development`. When I tried to switch back to `development`, VS Code said I had too many active changes and asked if I wanted to add Node modules to `.gitignore`. I checked 'Yes', but then it said to push my changes before I could switch back to `development`. So I did. I thought Node modules were already in the `.gitignore` for dev... If you can take a second look for me, maybe we can just close this PR without merging. 