### PR TITLE
Sliced sides array bc of weirdness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { Link } from "react-router-dom"
 function App() {
 
   const meals = menu.meals.slice(-6)
-  const sides = menu.meals.slice(26,40)
+  const sides = menu.meals.slice(33,40)
   const drinks = menu.drinks.slice(-6,-1)
   const desserts = menu.desserts.slice(0,6)
 


### PR DESCRIPTION
I had tried to create the sides array by mapping and using the conditional of `category.includes`... but this would throw an error. Patch for now is a different slice of the array so pasta dishes and nachos et al aren't included. Not an important fix, just can't leave things alone. 